### PR TITLE
Fix download urls in run.sh

### DIFF
--- a/.test/run.sh
+++ b/.test/run.sh
@@ -11,15 +11,15 @@ echo "${PLATFORM}"
 SHA1=$(curl -s http://d.defold.com/stable/info.json | sed 's/.*sha1": "\(.*\)".*/\1/')
 echo "Using Defold dmengine_headless version ${SHA1}"
 
-DMENGINE_URL="http://d.defold.com/archive/stable/${SHA1}/engine/${PLATFORM}/dmengine_headless"
-BOB_URL="http://d.defold.com/archive/stable/${SHA1}/bob/bob.jar"
+DMENGINE_URL="http://d.defold.com/archive/${SHA1}/engine/${PLATFORM}/dmengine_headless"
+BOB_URL="http://d.defold.com/archive/${SHA1}/bob/bob.jar"
 
 echo "Downloading ${DMENGINE_URL}"
-curl -o dmengine_headless ${DMENGINE_URL}
+curl -L -o dmengine_headless ${DMENGINE_URL}
 chmod +x dmengine_headless
 
 echo "Downloading ${BOB_URL}"
-curl -o bob.jar ${BOB_URL}
+curl -L -o bob.jar ${BOB_URL}
 
 echo "Running bob.jar"
 java -jar bob.jar --debug build

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -11,9 +11,8 @@ echo "${PLATFORM}"
 SHA1=$(curl -s http://d.defold.com/stable/info.json | sed 's/.*sha1": "\(.*\)".*/\1/')
 echo "Using Defold dmengine_headless version ${SHA1}"
 
-#DMENGINE_URL="http://d.defold.com/archive/${SHA1}/engine/linux/dmengine_headless"
-DMENGINE_URL="http://d.defold.com/archive/${SHA1}/engine/${PLATFORM}/dmengine_headless"
-BOB_URL="http://d.defold.com/archive/${SHA1}/bob/bob.jar"
+DMENGINE_URL="http://d.defold.com/archive/stable/${SHA1}/engine/${PLATFORM}/dmengine_headless"
+BOB_URL="http://d.defold.com/archive/stable/${SHA1}/bob/bob.jar"
 
 echo "Downloading ${DMENGINE_URL}"
 curl -o dmengine_headless ${DMENGINE_URL}


### PR DESCRIPTION
curl does not download a file when there is a redirect

```bash
$ ./.test/run.sh

x86_64-linux
Using Defold dmengine_headless version d9e9c49ab946c058f29a8b688c862d70f30e9c43
Downloading http://d.defold.com/archive/d9e9c49ab946c058f29a8b688c862d70f30e9c43/engine/x86_64-linux/dmengine_headless
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Downloading http://d.defold.com/archive/d9e9c49ab946c058f29a8b688c862d70f30e9c43/bob/bob.jar
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Running bob.jar
Error: Invalid or corrupt jarfile bob.jar
Starting dmengine_headless
```

Updated URLs fixed the issue:

```bash
$ ./.test/run.sh

x86_64-linux
Downloading http://d.defold.com/archive/stable/d9e9c49ab946c058f29a8b688c862d70f30e9c43/engine/x86_64-linux/dmengine_headless
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 21.6M  100 21.6M    0     0  30.5M      0 --:--:-- --:--:-- --:--:-- 30.7M
Downloading http://d.defold.com/archive/stable/d9e9c49ab946c058f29a8b688c862d70f30e9c43/bob/bob.jar
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  135M  100  135M    0     0  36.5M      0  0:00:03  0:00:03 --:--:-- 36.5M
Running bob.jar
WARNING option 'debug' is deprecated, use options 'variant' and 'strip-executable' instead.
Working...Reading classes... 1% ...done!
...
```