### PR TITLE
Run.sh script changes

### DIFF
--- a/.test/run.sh
+++ b/.test/run.sh
@@ -29,7 +29,7 @@ if [[ ! -f bob.jar ]]; then
 fi
 
 echo "Running bob.jar"
-java -jar bob.jar --variant debug build
+java -jar bob.jar --variant=debug build
 
 echo "Starting dmengine_headless"
 ./dmengine_headless

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -20,7 +20,7 @@ BOB_URL="http://d.defold.com/archive/${SHA1}/bob/bob.jar"
 if [[ ! -f dmengine_headless ]]; then
 	echo "Downloading ${DMENGINE_URL}"
 	curl -L -o dmengine_headless ${DMENGINE_URL}
-	chmod +x dmengine_headlessf
+	chmod +x dmengine_headless
 fi	
 
 if [[ ! -f bob.jar ]]; then

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -25,7 +25,7 @@ echo "Downloading ${BOB_URL}"
 curl -L -o bob.jar ${BOB_URL}
 
 echo "Running bob.jar"
-java -jar bob.jar --debug build
+java -jar bob.jar --variant debug build
 
 echo "Starting dmengine_headless"
 ./dmengine_headless

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -21,8 +21,10 @@ echo "Downloading ${DMENGINE_URL}"
 curl -L -o dmengine_headless ${DMENGINE_URL}
 chmod +x dmengine_headless
 
-echo "Downloading ${BOB_URL}"
-curl -L -o bob.jar ${BOB_URL}
+if [[ ! -f bob.jar ]]; then
+	echo "Downloading ${BOB_URL}"
+	curl -L -o bob.jar ${BOB_URL}
+fi
 
 echo "Running bob.jar"
 java -jar bob.jar --variant debug build

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -17,9 +17,11 @@ echo "Using Defold dmengine_headless version ${SHA1}"
 DMENGINE_URL="http://d.defold.com/archive/${SHA1}/engine/${PLATFORM}/dmengine_headless"
 BOB_URL="http://d.defold.com/archive/${SHA1}/bob/bob.jar"
 
-echo "Downloading ${DMENGINE_URL}"
-curl -L -o dmengine_headless ${DMENGINE_URL}
-chmod +x dmengine_headless
+if [[ ! -f dmengine_headless ]]; then
+	echo "Downloading ${DMENGINE_URL}"
+	curl -L -o dmengine_headless ${DMENGINE_URL}
+	chmod +x dmengine_headlessf
+fi	
 
 if [[ ! -f bob.jar ]]; then
 	echo "Downloading ${BOB_URL}"

--- a/.test/run.sh
+++ b/.test/run.sh
@@ -29,7 +29,7 @@ if [[ ! -f bob.jar ]]; then
 fi
 
 echo "Running bob.jar"
-java -jar bob.jar --variant=debug build
+java -jar bob.jar --variant=headless build
 
 echo "Starting dmengine_headless"
 ./dmengine_headless


### PR DESCRIPTION
A couple changes to the run.sh script. 
1) bob.jar argument --debug changed to --variant=headless, as debug is deprecated
2) adjusted the download dmengine_headless and bob.jar sections to only download if the files are not present. The script would re-download dmengine_headless and bob.jar on every run. This change is taken in part from this repo: https://github.com/defold/test-defold. There is no version checking and updating, if anyone has any ideas that would be great! 

Tested on my local linux environment, works as intended. Further testing required for CI integration.